### PR TITLE
Disable Doxygen's IMPLICIT_DIR_DOCS

### DIFF
--- a/src/poxy/run.py
+++ b/src/poxy/run.py
@@ -113,6 +113,7 @@ DOXYGEN_DEFAULTS = (
     (r'HTML_FILE_EXTENSION', r'.html'),
     (r'HTML_OUTPUT', r'html'),
     (r'IDL_PROPERTY_SUPPORT', False),
+    (r'IMPLICIT_DIR_DOCS', False),
     (r'INHERIT_DOCS', True),
     (r'INLINE_GROUPED_CLASSES', False),
     (r'INLINE_INFO', True),


### PR DESCRIPTION
Hi @marzer,

Doxygen v1.13 introduced the IMPLICIT_DIR_DOCS option with a default value of True. This means that README.md files in subdirectories are treated as directory descriptions, replacing the "page" entry in the tag file with a "dir" entry. In my projects, these documents disappeared from Poxy's output, resulting in broken links.

This PR disables IMPLICIT_DIR_DOCS. I would be grateful if you could consider merging it to restore the previous behaviour.